### PR TITLE
guieditor_branch 2차완성

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import {
   Routes,
   Route,
 } from "react-router-dom";
+import GuiEditorForm from './components/GuiPage/GuiEditor.jsx';
 
 function App() {
 
@@ -13,6 +14,7 @@ function App() {
       <Routes>
         <Route path="/" element={<ConnectDBPage />} />
         <Route path="/home" element={< MainPageForm />} />
+        <Route path="/gui" element={<GuiEditorForm/>}/>
       </Routes>
     </div>
   )


### PR DESCRIPTION
특이사항 : 
첫째, 버튼 클릭시 항상 스페이스바나 엔터나 데이터를 넣어줘야합니다. 
이유 : monaco editor에서 변동사항이 있어야 커서를 바꿔주는 것으로 보입니다.

둘째, 처음에 constant.js 로 할경우 작동안합니다.
이유 : 데이터를 '\n' 줄바꿈으로 데이터 split해서 가져오기 떄문에, constant.js 파일에 있는 데이터는  '\n'을 기반으로 나눠져 있지 않고, bson = ' ~~~' 으로 되어있어 작동안합니다. 

셋째, 이전 파이프라인에 대한 ',' 콤마 처리는 없습니다.


